### PR TITLE
Change serialized name of second unlocalizedName

### DIFF
--- a/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
+++ b/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
@@ -2,12 +2,12 @@ package mantle.blocks.abstracts;
 
 import static mantle.lib.CoreRepo.logger;
 
-import com.google.gson.annotations.SerializedName;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
+
+import com.google.gson.annotations.SerializedName;
 
 /**
  * 

--- a/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
+++ b/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
@@ -15,21 +15,21 @@ import net.minecraft.util.MathHelper;
 public class MultiItemBlock extends ItemBlock {
 
     private String blockType[];
-    private String unlocalizedName;
+    private String unlocalizedNameSecond;
     private String append;
     private int specialIndex[] = { -1, -1 };
 
     public MultiItemBlock(Block b, String itemBlockUnlocalizedName, String[] blockTypes) {
         super(b);
-        if (itemBlockUnlocalizedName.isEmpty()) this.unlocalizedName = super.getUnlocalizedName();
-        else this.unlocalizedName = itemBlockUnlocalizedName;
+        if (itemBlockUnlocalizedName.isEmpty()) this.unlocalizedNameSecond = super.getUnlocalizedName();
+        else this.unlocalizedNameSecond = itemBlockUnlocalizedName;
         this.blockType = blockTypes;
         this.append = "";
     }
 
     public MultiItemBlock(Block b, String itemBlockUnlocalizedName, String appendToEnd, String[] blockTypes) {
         super(b);
-        this.unlocalizedName = itemBlockUnlocalizedName;
+        this.unlocalizedNameSecond = itemBlockUnlocalizedName;
         this.blockType = blockTypes;
         this.append = "." + appendToEnd;
     }
@@ -52,7 +52,7 @@ public class MultiItemBlock extends ItemBlock {
         int sbIndex = (specialIndex[1] > -1) ? pos : (specialIndex[1] - pos);
         if (sbIndex < 0) sbIndex = -1 * sbIndex;
         try {
-            return (new StringBuilder()).append(unlocalizedName).append(".").append(blockType[sbIndex - 1])
+            return (new StringBuilder()).append(unlocalizedNameSecond).append(".").append(blockType[sbIndex - 1])
                     .append(append).toString();
         } catch (ArrayIndexOutOfBoundsException ex) {
             logger.warn("[MultiItemBlock] Caught array index error in getUnlocalizedName: " + ex.getMessage());

--- a/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
+++ b/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
@@ -2,6 +2,8 @@ package mantle.blocks.abstracts;
 
 import static mantle.lib.CoreRepo.logger;
 
+import com.google.gson.annotations.SerializedName;
+
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -15,21 +17,22 @@ import net.minecraft.util.MathHelper;
 public class MultiItemBlock extends ItemBlock {
 
     private String blockType[];
-    private String unlocalizedNameSecond;
+    @SerializedName("secondUnlocalizedName")
+    private String unlocalizedName;
     private String append;
     private int specialIndex[] = { -1, -1 };
 
     public MultiItemBlock(Block b, String itemBlockUnlocalizedName, String[] blockTypes) {
         super(b);
-        if (itemBlockUnlocalizedName.isEmpty()) this.unlocalizedNameSecond = super.getUnlocalizedName();
-        else this.unlocalizedNameSecond = itemBlockUnlocalizedName;
+        if (itemBlockUnlocalizedName.isEmpty()) this.unlocalizedName = super.getUnlocalizedName();
+        else this.unlocalizedName = itemBlockUnlocalizedName;
         this.blockType = blockTypes;
         this.append = "";
     }
 
     public MultiItemBlock(Block b, String itemBlockUnlocalizedName, String appendToEnd, String[] blockTypes) {
         super(b);
-        this.unlocalizedNameSecond = itemBlockUnlocalizedName;
+        this.unlocalizedName = itemBlockUnlocalizedName;
         this.blockType = blockTypes;
         this.append = "." + appendToEnd;
     }
@@ -52,7 +55,7 @@ public class MultiItemBlock extends ItemBlock {
         int sbIndex = (specialIndex[1] > -1) ? pos : (specialIndex[1] - pos);
         if (sbIndex < 0) sbIndex = -1 * sbIndex;
         try {
-            return (new StringBuilder()).append(unlocalizedNameSecond).append(".").append(blockType[sbIndex - 1])
+            return (new StringBuilder()).append(unlocalizedName).append(".").append(blockType[sbIndex - 1])
                     .append(append).toString();
         } catch (ArrayIndexOutOfBoundsException ex) {
             logger.warn("[MultiItemBlock] Caught array index error in getUnlocalizedName: " + ex.getMessage());

--- a/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
+++ b/src/main/java/mantle/blocks/abstracts/MultiItemBlock.java
@@ -17,7 +17,7 @@ import net.minecraft.util.MathHelper;
 public class MultiItemBlock extends ItemBlock {
 
     private String blockType[];
-    @SerializedName("secondUnlocalizedName")
+    @SerializedName(value = "secondUnlocalizedName")
     private String unlocalizedName;
     private String append;
     private int specialIndex[] = { -1, -1 };


### PR DESCRIPTION
allows TiCon blocks to be serialized to Json using Gson
![image](https://user-images.githubusercontent.com/76872108/218572985-b88cf36f-34de-4212-ba7c-849d58fc5b03.png)
