### PR TITLE
Fix ArrayIndexOutOfBoundsException in getUnlocalizedName

### DIFF
--- a/src/main/java/mantle/items/abstracts/CraftingItem.java
+++ b/src/main/java/mantle/items/abstracts/CraftingItem.java
@@ -59,7 +59,7 @@ public class CraftingItem extends Item {
     }
 
     public String getUnlocalizedName(ItemStack stack) {
-        int arr = MathHelper.clamp_int(stack.getItemDamage(), 0, unlocalizedNames.length);
+        int arr = MathHelper.clamp_int(stack.getItemDamage(), 0, unlocalizedNames.length - 1);
         return getUnlocalizedName() + "." + unlocalizedNames[arr];
     }
 


### PR DESCRIPTION
Fixes the following crash:

```
java.lang.ArrayIndexOutOfBoundsException: Index 5 out of bounds for length 5
    at mantle.items.abstracts.CraftingItem.getUnlocalizedName(CraftingItem.java:63)
    at net.minecraft.item.Item.getUnlocalizedNameInefficiently(Item.java:547)
    at net.minecraft.item.Item.getItemStackDisplayName(Item.java:636)
    at net.minecraft.item.ItemStack.getDisplayName(ItemStack.java:427)
    at squeek.tictooltips.TooltipHandler.getToolPartTooltip(TooltipHandler.java:1068)
    at squeek.tictooltips.TooltipHandler.getToolMaterialsTooltip(TooltipHandler.java:1030)
    at squeek.tictooltips.TooltipHandler.onItemTooltip(TooltipHandler.java:162)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler_1882_TooltipHandler_onItemTooltip_ItemTooltipEvent.invoke(.dynamic)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
    at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
    at net.minecraftforge.event.ForgeEventFactory.onItemTooltip(ForgeEventFactory.java:169)
    at net.minecraft.item.ItemStack.getTooltip(ItemStack.java:626)
    at com.gtnewhorizons.modularui.api.drawable.GuiHelper.getItemTooltip(GuiHelper.java:458)
    at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.renderToolTip(ModularGui.java:416)
    at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.drawGuiContainerForegroundLayer(ModularGui.java:289)
    at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.drawScreen(ModularGui.java:158)
    at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1061)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1001)
    at net.minecraft.client.Minecraft.run(Minecraft.java:5110)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:219)
```