### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/mantle/lang/en_US.lang
+++ b/src/main/resources/assets/mantle/lang/en_US.lang
@@ -1,0 +1,1 @@
+Mantle:item.mantle.manual.name=Manual


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.